### PR TITLE
Default ports for Kafka and Zookeeper should be avoided

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -88,8 +88,7 @@ public class MavenWrapperDownloader {
             System.out.println("Done");
             System.exit(0);
         } catch (Throwable e) {
-            System.out.println("- Error downloading");
-            e.printStackTrace();
+            System.out.println("- Error downloading:"  + e.getMessage() );
             System.exit(1);
         }
     }

--- a/src/main/docker/docker-compose.yaml
+++ b/src/main/docker/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     networks:
       - test-net
     ports:
-      - 2181:2181
+      - 2180:2180
     environment:
       zk_id: "1"
 
@@ -19,12 +19,12 @@ services:
     networks:
       - test-net
     ports:
-      - 9092:9092
+      - 9002:9002
     environment:
       KAFKA_ADVERTISED_HOST_NAME: "kafka"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9002
       KAFKA_BROKER_ID: "0"
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2180"
 
   schema-registry:
     image: confluent/schema-registry:3.0.0


### PR DESCRIPTION
Why
Default ports are susceptible to vulnerabilities

Description
Most cyber attacks occur due to default port usage.

Reff: https://www.bleepingcomputer.com/news/security/most-cyber-attacks-focus-on-just-three-tcp-ports/#:~:text=According%20to%20the%20report%2C%20the,(Hypertext%20Transfer%20Protocol%20Secure)